### PR TITLE
PEFNamespaceContext doesn't compile with Java 10

### DIFF
--- a/src/org/daisy/braille/utils/pef/PEFNamespaceContext.java
+++ b/src/org/daisy/braille/utils/pef/PEFNamespaceContext.java
@@ -17,9 +17,9 @@
  */
 package org.daisy.braille.utils.pef;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Map.Entry;
 
 import javax.xml.namespace.NamespaceContext;
 
@@ -73,8 +73,8 @@ public class PEFNamespaceContext implements NamespaceContext {
 	}
 
 	@Override
-	public Iterator<Entry<String, String>> getPrefixes(String namespaceURI) {
-		return prefixes.entrySet().iterator();
+	public Iterator<String> getPrefixes(String namespaceURI) {
+		return Collections.singleton(getPrefix(namespaceURI)).iterator();
 	}
 
 }


### PR DESCRIPTION
The return type of `NamespaceContext.getPrefixes()` changed to `Iterator<String>` in Java 10 and this breaks PEFNamespaceContext. Here is a suggestion to fix this issue.